### PR TITLE
Added int conversion for StartPulse

### DIFF
--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/Program.fs
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/Program.fs
@@ -14,7 +14,7 @@ type MeadowApp() =
                       Meadow.Peripherals.Leds.IRgbLed.CommonType.CommonAnode)
 
     let ShowColorPulses color duration =
-        led.StartPulse(color, (duration / 2u)) |> ignore
+        led.StartPulse(color, int (duration / 2u)) |> ignore
         Threading.Thread.Sleep(int duration) |> ignore
         led.Stop |> ignore
 


### PR DESCRIPTION
duration / 2u is a uint32, whereas StartPulse expects an int for the pulseDuration parameter. This is a compiler error, so the application won't run without this fix.