### PR TITLE
Add missing NuGet package icon

### DIFF
--- a/Meadow_DotNet_SDK/Meadow.SDK/Meadow.Sdk.csproj
+++ b/Meadow_DotNet_SDK/Meadow.SDK/Meadow.Sdk.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Meadow.Sdk</AssemblyName>
     <PackageProjectUrl>https://github.com/WildernessLabs/NugetTest</PackageProjectUrl>
     <PackageId>Meadow.Sdk</PackageId>
+    <PackageIcon>icon.png</PackageIcon>
     <Authors>Bryan Costanich, Adrian Stevens</Authors>
     <Copyright>Wilderness Labs</Copyright>
     <Owners>Wilderness Labs</Owners>
@@ -19,5 +20,6 @@
   <ItemGroup>
     <None Update="sdk\Sdk.props" PackagePath="sdk\Sdk.props" Pack="true" />
     <None Update="sdk\Sdk.targets" PackagePath="sdk\Sdk.targets" Pack="true" />
+    <None Include="..\icon.png" PackagePath="icon.png" Pack="true" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Trying to align this package with the others.

![NuGet screenshot showing default package icon.](https://user-images.githubusercontent.com/713665/202885083-1888112d-098f-4901-b66e-a1aaa21765b7.png)

https://www.nuget.org/packages/Meadow.MQTT