### PR TITLE
Core-Compute templates (plus Resolver.Log use)

### DIFF
--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/MeadowApp.cs
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/MeadowApp.cs
@@ -16,7 +16,7 @@ namespace MeadowApp
 
 		public override Task Run()
 		{
-			Console.WriteLine("Run...");
+			Resolver.Log.Info("Run...");
 
 			CycleColors(TimeSpan.FromMilliseconds(1000));
 			return base.Run();
@@ -24,7 +24,7 @@ namespace MeadowApp
 
 		public override Task Initialize()
 		{
-			Console.WriteLine("Initialize...");
+			Resolver.Log.Info("Initialize...");
 
 			onboardLed = new RgbPwmLed(device: Device,
 				redPwmPin: Device.Pins.OnboardLedRed,
@@ -37,7 +37,7 @@ namespace MeadowApp
 
 		void CycleColors(TimeSpan duration)
 		{
-			Console.WriteLine("Cycle colors...");
+			Resolver.Log.Info("Cycle colors...");
 
 			while (true)
 			{

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/MeadowApplication.csproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/MeadowApplication.csproj
@@ -13,5 +13,8 @@
     <None Update="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/app.config.yaml
@@ -1,0 +1,3 @@
+Lifecycle:
+    RestartOnAppFailure: false
+    AppFailureRestartDelaySeconds: 15

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/.template.config/template.json
@@ -1,0 +1,18 @@
+﻿{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Wilderness Labs",
+  "classifications": [ "Meadow", "Console" ],
+  "name": "Meadow Application (Core-Compute module)",
+  "identity": "WildernessLabs.Meadow.Templates.BasicCcmApp",
+  "groupIdentity": "WildernessLabs.Meadow.BasicCcmApp",
+  "shortName": "MeadowCcm",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "MeadowApplication",
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    { "path": "MeadowApplication.csproj" }
+  ]
+}

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/.vscode/launch.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApp.cs
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApp.cs
@@ -1,0 +1,29 @@
+﻿using Meadow;
+using Meadow.Devices;
+using Meadow.Foundation;
+using Meadow.Foundation.Leds;
+using Meadow.Peripherals.Leds;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MeadowApp
+{
+	// Change F7CoreComputeV2 to F7FeatherV2 (or F7FeatherV1) for Feather boards
+	public class MeadowApp : App<F7CoreComputeV2>
+	{
+		public override Task Run()
+		{
+			Resolver.Log.Info("Run...");
+
+			return base.Run();
+		}
+
+		public override Task Initialize()
+		{
+			Resolver.Log.Info("Initialize...");
+
+			return base.Initialize();
+		}
+	}
+}

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApp.cs
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApp.cs
@@ -16,6 +16,8 @@ namespace MeadowApp
 		{
 			Resolver.Log.Info("Run...");
 
+			Resolver.Log.Info("Hello, Meadow Core-Compute!");
+
 			return base.Run();
 		}
 

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApplication.csproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApplication.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Meadow.Sdk/1.1.0">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <OutputType>Library</OutputType>
+    <AssemblyName>App</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Meadow.Foundation" Version="0.*" />
+    <PackageReference Include="Meadow.F7" Version="0.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="meadow.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApplication.csproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApplication.csproj
@@ -13,5 +13,8 @@
     <None Update="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/WildernessLabs.MeadowApp.Template.nuspec
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/WildernessLabs.MeadowApp.Template.nuspec
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>WildernessLabs.Meadow.App.Template</id>
+    <version>0.9.0</version>
+    <title>Wilderness Labs Meadow App Core-Compute Module Project Template</title>
+    <authors>Wilderness Labs</authors>
+    <owners>Wilderness Labs</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Meadow Core-Compute module application template</description>
+    <copyright>2019-2022</copyright>
+    <tags>Wilderness Labs Meadow App Sdk dotnet-new templates</tags>
+    <packageTypes>
+      <packageType name="Template" />
+    </packageTypes>
+    <dependencies>
+      <group targetFramework="netstandard2.1" />
+    </dependencies>
+  </metadata>
+</package>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/app.config.yaml
@@ -1,0 +1,3 @@
+Lifecycle:
+    RestartOnAppFailure: false
+    AppFailureRestartDelaySeconds: 15

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/meadow.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/meadow.config.yaml
@@ -1,0 +1,2 @@
+﻿MonoControl:
+    Options: --jit

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/.template.config/template.json
@@ -1,0 +1,18 @@
+﻿{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Wilderness Labs",
+  "classifications": [ "Meadow", "Console" ],
+  "name": "Meadow Application",
+  "identity": "WildernessLabs.Meadow.Templates.BasicCcmApp.FSharp",
+  "groupIdentity": "WildernessLabs.Meadow.BasicCcmApp",
+  "shortName": "MeadowCcm",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "sourceName": "MeadowApplication",
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    { "path": "MeadowApplication.fsproj" }
+  ]
+}

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/.vscode/launch.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/MeadowApplication.fsproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/MeadowApplication.fsproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Meadow.Sdk/1.1.0">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <OutputType>Library</OutputType>
+    <AssemblyName>App</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Meadow.Foundation" Version="0.*" />
+    <PackageReference Include="Meadow.F7" Version="0.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="meadow.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/MeadowApplication.fsproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/MeadowApplication.fsproj
@@ -16,5 +16,8 @@
     <None Include="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/Program.fs
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/Program.fs
@@ -1,4 +1,4 @@
-﻿namespace MeadowApp
+namespace MeadowApp
 
 open System
 open Meadow.Devices
@@ -18,5 +18,7 @@ type MeadowApp() =
         
     override this.Run () =
         do Resolver.Log.Info "Run... (F#)"
+
+        do Resolver.Log.Info "Hello, Meadow Core-Compute!"
 
         base.Run()

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/Program.fs
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/Program.fs
@@ -1,0 +1,22 @@
+﻿namespace MeadowApp
+
+open System
+open Meadow.Devices
+open Meadow
+open Meadow.Foundation.Leds
+open Meadow.Foundation
+open Meadow.Peripherals.Leds
+
+type MeadowApp() =
+    // Change F7CoreComputeV2 to F7FeatherV2 (or F7FeatherV1) for Feather boards
+	inherit App<F7CoreComputeV2>()
+
+    override this.Initialize() =
+        do Resolver.Log.Info "Initialize... (F#)"
+
+        base.Initialize()
+        
+    override this.Run () =
+        do Resolver.Log.Info "Run... (F#)"
+
+        base.Run()

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/Program.fs
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/Program.fs
@@ -9,7 +9,7 @@ open Meadow.Peripherals.Leds
 
 type MeadowApp() =
     // Change F7CoreComputeV2 to F7FeatherV2 (or F7FeatherV1) for Feather boards
-	inherit App<F7CoreComputeV2>()
+    inherit App<F7CoreComputeV2>()
 
     override this.Initialize() =
         do Resolver.Log.Info "Initialize... (F#)"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/WildernessLabs.MeadowApp.FSharp.Template.nuspec
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/WildernessLabs.MeadowApp.FSharp.Template.nuspec
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>WildernessLabs.Meadow.App.FSharp.Template</id>
+    <version>0.9.0</version>
+    <title>Wilderness Labs Meadow App Project Template</title>
+    <authors>Wilderness Labs</authors>
+    <owners>Wilderness Labs</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Meadow application template</description>
+    <copyright>2019-2022</copyright>
+    <tags>Wilderness Labs Meadow App Sdk dotnet-new templates FSharp</tags>
+    <packageTypes>
+      <packageType name="Template" />
+    </packageTypes>
+    <dependencies>
+      <group targetFramework="netstandard2.1" />
+    </dependencies>
+  </metadata>
+</package>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/app.config.yaml
@@ -1,0 +1,3 @@
+Lifecycle:
+    RestartOnAppFailure: false
+    AppFailureRestartDelaySeconds: 15

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/meadow.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/meadow.config.yaml
@@ -1,0 +1,2 @@
+﻿MonoControl:
+    Options: --jit

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/.template.config/template.json
@@ -1,0 +1,18 @@
+﻿{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Wilderness Labs",
+  "classifications": [ "Meadow", "Console" ],
+  "name": "Meadow Application (Core-Compute module)",
+  "identity": "WildernessLabs.Meadow.Templates.BasicCcmApp.VBNet",
+  "groupIdentity": "WildernessLabs.Meadow.BasicCcmApp",
+  "shortName": "MeadowCcm",
+  "tags": {
+    "language": "VB.NET",
+    "type": "project"
+  },
+  "sourceName": "MeadowApplication",
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    { "path": "MeadowApplication.csproj" }
+  ]
+}

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/.vscode/launch.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApp.vb
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApp.vb
@@ -12,6 +12,8 @@ Public Class MeadowApp
     Public Overrides Function Run() As Task
         Resolver.Log.Info("Run... (VB.NET)")
 
+        Resolver.Log.Info("Hello, Meadow Core-Compute!");
+
         Return MyBase.Run()
     End Function
 

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApp.vb
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApp.vb
@@ -12,7 +12,7 @@ Public Class MeadowApp
     Public Overrides Function Run() As Task
         Resolver.Log.Info("Run... (VB.NET)")
 
-        Resolver.Log.Info("Hello, Meadow Core-Compute!");
+        Resolver.Log.Info("Hello, Meadow Core-Compute!")
 
         Return MyBase.Run()
     End Function

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApp.vb
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApp.vb
@@ -1,0 +1,23 @@
+﻿Imports System.Threading
+Imports Meadow
+Imports Meadow.Devices
+Imports Meadow.Foundation
+Imports Meadow.Foundation.Leds
+Imports Meadow.Peripherals.Leds
+
+Public Class MeadowApp
+    ' Change F7CoreComputeV2 to F7FeatherV2 (or F7FeatherV1) for Feather boards
+    Inherits App(Of F7CoreComputeV2)
+
+    Public Overrides Function Run() As Task
+        Resolver.Log.Info("Run... (VB.NET)")
+
+        Return MyBase.Run()
+    End Function
+
+    Public Overrides Function Initialize() As Task
+        Resolver.Log.Info("Initialize... (VB.NET)")
+
+        Return MyBase.Run()
+    End Function
+End Class

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApplication.vbproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApplication.vbproj
@@ -1,0 +1,17 @@
+<Project Sdk="Meadow.Sdk/1.1.0">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <AssemblyName>App</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Meadow.Foundation" Version="0.*" />
+    <PackageReference Include="Meadow.F7" Version="0.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="meadow.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApplication.vbproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApplication.vbproj
@@ -13,5 +13,8 @@
     <None Update="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/WildernessLabs.MeadowApp.Template.nuspec
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/WildernessLabs.MeadowApp.Template.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
-    <id>WildernessLabs.Meadow.App.VBNet.Template</id>
+    <id>WildernessLabs.Meadow.App.Template</id>
     <version>0.9.0</version>
     <title>Wilderness Labs Meadow App Core-Compute Module Project Template</title>
     <authors>Wilderness Labs</authors>
@@ -9,7 +9,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Meadow Core-Compute module application template</description>
     <copyright>2019-2022</copyright>
-    <tags>Wilderness Labs Meadow App Sdk dotnet-new templates VB.Net</tags>
+    <tags>Wilderness Labs Meadow App Sdk dotnet-new templates</tags>
     <packageTypes>
       <packageType name="Template" />
     </packageTypes>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/app.config.yaml
@@ -1,0 +1,3 @@
+Lifecycle:
+    RestartOnAppFailure: false
+    AppFailureRestartDelaySeconds: 15

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/meadow.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/meadow.config.yaml
@@ -1,0 +1,2 @@
+﻿MonoControl:
+    Options: --jit

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/MeadowApplication.fsproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/MeadowApplication.fsproj
@@ -16,5 +16,8 @@
     <None Include="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/Program.fs
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/Program.fs
@@ -20,7 +20,7 @@ type MeadowApp() =
         led.Stop |> ignore
     
     let CycleColors (duration : TimeSpan)  = 
-        do Console.WriteLine "Cycle colors..."
+        do Resolver.Log.Info "Cycle colors..."
 
         while true do
             ShowColorPulse Color.Blue duration 
@@ -37,7 +37,7 @@ type MeadowApp() =
             ShowColorPulse Color.Pink duration
 
     override this.Initialize() =
-        do Console.WriteLine "Initialize... (F#)"
+        do Resolver.Log.Info "Initialize... (F#)"
 
         led <- new RgbPwmLed(MeadowApp.Device, 
             MeadowApp.Device.Pins.OnboardLedRed,
@@ -48,7 +48,7 @@ type MeadowApp() =
         base.Initialize()
         
     override this.Run () =
-        do Console.WriteLine "Run... (F#)"
+        do Resolver.Log.Info "Run... (F#)"
 
         do CycleColors (TimeSpan.FromSeconds(1))
 

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/app.config.yaml
@@ -1,0 +1,3 @@
+Lifecycle:
+    RestartOnAppFailure: false
+    AppFailureRestartDelaySeconds: 15

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/MeadowApp.vb
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/MeadowApp.vb
@@ -12,7 +12,7 @@ Public Class MeadowApp
     Private onboardLed As RgbPwmLed
 
     Public Overrides Function Run() As Task
-        Console.WriteLine("Run... (VB.NET)")
+        Resolver.Log.Info("Run... (VB.NET)")
 
         CycleColors(TimeSpan.FromMilliseconds(1000))
 
@@ -20,7 +20,7 @@ Public Class MeadowApp
     End Function
 
     Public Overrides Function Initialize() As Task
-        Console.WriteLine("Initialize... (VB.NET)")
+        Resolver.Log.Info("Initialize... (VB.NET)")
 
         onboardLed = New RgbPwmLed(Device,
             Device.Pins.OnboardLedRed,
@@ -32,7 +32,7 @@ Public Class MeadowApp
     End Function
 
     Private Sub CycleColors(ByVal duration As TimeSpan)
-        Console.WriteLine("Cycle colors...")
+        Resolver.Log.Info("Cycle colors...")
 
         While True
             ShowColorPulse(Color.Blue, duration)

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/MeadowApplication.vbproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/MeadowApplication.vbproj
@@ -14,5 +14,8 @@
     <None Update="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/app.config.yaml
@@ -1,0 +1,3 @@
+Lifecycle:
+    RestartOnAppFailure: false
+    AppFailureRestartDelaySeconds: 15

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryVBNet/Class1.vb
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryVBNet/Class1.vb
@@ -8,6 +8,6 @@ Imports System.Threading
 Public Class Class1
 	
 	Public Shared Sub Main()
-		Console.WriteLine("Hello very modern world!")
+		Resolver.Log.Info("Hello very modern world!")
 	End Sub
 End Class


### PR DESCRIPTION
- [x] Core-Compute template (C#)
- [x] Core-Compute template (VB)
- [x] Core-Compute template (F#)
- [x] Update all templates to use `Resolver.Log` instead of `Console.WriteLine`
- [x] Update all templates to disable app restart on failure
- [x] Validate templates generate projects
    - [x] C#
    - [x] VB
    - [x] F#