### PR TITLE
Sample config files for templates

### DIFF
--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/app.config.yaml
@@ -1,3 +1,14 @@
+# Uncomment additional options as needed.
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/Application_Settings_Configuration/
+
 Lifecycle:
+    # Control whether Meadow will restart when an unhandled app exception occurs. Combine with Lifecycle > AppFailureRestartDelaySeconds to control restart timing.
     RestartOnAppFailure: false
-    AppFailureRestartDelaySeconds: 15
+    # # When app set to restart automatically on app failure, 
+    # AppFailureRestartDelaySeconds: 15
+
+# # Adjust the level of logging detail.
+# Logging:
+#     LogLevel:
+#         Default: "Trace"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/meadow.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/meadow.config.yaml
@@ -1,2 +1,43 @@
-﻿MonoControl:
-    Options: --jit
+﻿# Uncommented these options as needed.
+# To learn more about these config options, check out the OS & Device Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/
+
+# Device:
+#     # Name of the device on the network.
+#     Name: MeadowF7V2_ConfigSample
+#
+#     # Uncomment if SD card hardware present on this hardware (e.g., Core-Compute module with SD add-on)? Optional; default value is `false`.
+#     SdStorageSupported: true
+# MonoControl:
+#     # Options allow enabling debug builds or controlling JIT compilation (`--jit` to enable [default], `--interp` to disable).
+#     Options: --interp --debug
+# # Control how the ESP coprocessor will start and operate.
+# Coprocessor:
+#     # Should the ESP32 automatically attempt to connect to an access point at startup?
+#     # If set to true, wifi.config.yaml credentials must be stored in the device.
+#     AutomaticallyStartNetwork: true
+#
+#     # Should the ESP32 automatically reconnect to the configured access point?
+#     AutomaticallyReconnect: true
+#
+#     # Maximum number of retry attempts for connections etc. before an error code is returned.
+#     MaximumRetryCount: 7
+# # Network configuration.
+# Network:
+#     # Automatically attempt to get the time at startup?
+#     GetNetworkTimeAtStartup: true
+#
+#     # Time synchronization period in seconds.
+#     NtpRefreshPeriod: 600
+#
+#     # Name of the NTP servers.
+#     NtpServers:
+#         - 0.pool.ntp.org
+#         - 1.pool.ntp.org
+#         - 2.pool.ntp.org
+#         - 3.pool.ntp.org
+#
+#     # IP addresses of the DNS servers.
+#     DnsServers:
+#         - 1.1.1.1
+#         - 8.8.8.8

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/wifi.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/wifi.config.yaml
@@ -1,0 +1,8 @@
+# Uncomment to set the default Wi-Fi credentials. (This file will be processed into secure storage on the ESP32 and then deleted from the device.)
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/WiFi_Configuration/
+
+# # To enable automatically connecting to a default network, make sure to enable the Coprocessor > AutomaticallyStartNetwork value in meadow.config.yaml.
+# Credentials:
+#     Ssid: YourSSID
+#     Password: SSIDPassword

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/app.config.yaml
@@ -1,3 +1,14 @@
+# Uncomment additional options as needed.
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/Application_Settings_Configuration/
+
 Lifecycle:
+    # Control whether Meadow will restart when an unhandled app exception occurs. Combine with Lifecycle > AppFailureRestartDelaySeconds to control restart timing.
     RestartOnAppFailure: false
-    AppFailureRestartDelaySeconds: 15
+    # # When app set to restart automatically on app failure, 
+    # AppFailureRestartDelaySeconds: 15
+
+# # Adjust the level of logging detail.
+# Logging:
+#     LogLevel:
+#         Default: "Trace"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/meadow.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/meadow.config.yaml
@@ -1,2 +1,43 @@
-﻿MonoControl:
-    Options: --jit
+﻿# Uncommented these options as needed.
+# To learn more about these config options, check out the OS & Device Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/
+
+# Device:
+#     # Name of the device on the network.
+#     Name: MeadowF7V2_ConfigSample
+#
+#     # Uncomment if SD card hardware present on this hardware (e.g., Core-Compute module with SD add-on)? Optional; default value is `false`.
+#     SdStorageSupported: true
+# MonoControl:
+#     # Options allow enabling debug builds or controlling JIT compilation (`--jit` to enable [default], `--interp` to disable).
+#     Options: --interp --debug
+# # Control how the ESP coprocessor will start and operate.
+# Coprocessor:
+#     # Should the ESP32 automatically attempt to connect to an access point at startup?
+#     # If set to true, wifi.config.yaml credentials must be stored in the device.
+#     AutomaticallyStartNetwork: true
+#
+#     # Should the ESP32 automatically reconnect to the configured access point?
+#     AutomaticallyReconnect: true
+#
+#     # Maximum number of retry attempts for connections etc. before an error code is returned.
+#     MaximumRetryCount: 7
+# # Network configuration.
+# Network:
+#     # Automatically attempt to get the time at startup?
+#     GetNetworkTimeAtStartup: true
+#
+#     # Time synchronization period in seconds.
+#     NtpRefreshPeriod: 600
+#
+#     # Name of the NTP servers.
+#     NtpServers:
+#         - 0.pool.ntp.org
+#         - 1.pool.ntp.org
+#         - 2.pool.ntp.org
+#         - 3.pool.ntp.org
+#
+#     # IP addresses of the DNS servers.
+#     DnsServers:
+#         - 1.1.1.1
+#         - 8.8.8.8

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/wifi.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/wifi.config.yaml
@@ -1,0 +1,8 @@
+# Uncomment to set the default Wi-Fi credentials. (This file will be processed into secure storage on the ESP32 and then deleted from the device.)
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/WiFi_Configuration/
+
+# # To enable automatically connecting to a default network, make sure to enable the Coprocessor > AutomaticallyStartNetwork value in meadow.config.yaml.
+# Credentials:
+#     Ssid: YourSSID
+#     Password: SSIDPassword

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/app.config.yaml
@@ -1,3 +1,14 @@
+# Uncomment additional options as needed.
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/Application_Settings_Configuration/
+
 Lifecycle:
+    # Control whether Meadow will restart when an unhandled app exception occurs. Combine with Lifecycle > AppFailureRestartDelaySeconds to control restart timing.
     RestartOnAppFailure: false
-    AppFailureRestartDelaySeconds: 15
+    # # When app set to restart automatically on app failure, 
+    # AppFailureRestartDelaySeconds: 15
+
+# # Adjust the level of logging detail.
+# Logging:
+#     LogLevel:
+#         Default: "Trace"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/meadow.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/meadow.config.yaml
@@ -1,2 +1,43 @@
-﻿MonoControl:
-    Options: --jit
+﻿# Uncommented these options as needed.
+# To learn more about these config options, check out the OS & Device Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/
+
+# Device:
+#     # Name of the device on the network.
+#     Name: MeadowF7V2_ConfigSample
+#
+#     # Uncomment if SD card hardware present on this hardware (e.g., Core-Compute module with SD add-on)? Optional; default value is `false`.
+#     SdStorageSupported: true
+# MonoControl:
+#     # Options allow enabling debug builds or controlling JIT compilation (`--jit` to enable [default], `--interp` to disable).
+#     Options: --interp --debug
+# # Control how the ESP coprocessor will start and operate.
+# Coprocessor:
+#     # Should the ESP32 automatically attempt to connect to an access point at startup?
+#     # If set to true, wifi.config.yaml credentials must be stored in the device.
+#     AutomaticallyStartNetwork: true
+#
+#     # Should the ESP32 automatically reconnect to the configured access point?
+#     AutomaticallyReconnect: true
+#
+#     # Maximum number of retry attempts for connections etc. before an error code is returned.
+#     MaximumRetryCount: 7
+# # Network configuration.
+# Network:
+#     # Automatically attempt to get the time at startup?
+#     GetNetworkTimeAtStartup: true
+#
+#     # Time synchronization period in seconds.
+#     NtpRefreshPeriod: 600
+#
+#     # Name of the NTP servers.
+#     NtpServers:
+#         - 0.pool.ntp.org
+#         - 1.pool.ntp.org
+#         - 2.pool.ntp.org
+#         - 3.pool.ntp.org
+#
+#     # IP addresses of the DNS servers.
+#     DnsServers:
+#         - 1.1.1.1
+#         - 8.8.8.8

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/wifi.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/wifi.config.yaml
@@ -1,0 +1,8 @@
+# Uncomment to set the default Wi-Fi credentials. (This file will be processed into secure storage on the ESP32 and then deleted from the device.)
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/WiFi_Configuration/
+
+# # To enable automatically connecting to a default network, make sure to enable the Coprocessor > AutomaticallyStartNetwork value in meadow.config.yaml.
+# Credentials:
+#     Ssid: YourSSID
+#     Password: SSIDPassword

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/app.config.yaml
@@ -1,3 +1,14 @@
+# Uncomment additional options as needed.
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/Application_Settings_Configuration/
+
 Lifecycle:
+    # Control whether Meadow will restart when an unhandled app exception occurs. Combine with Lifecycle > AppFailureRestartDelaySeconds to control restart timing.
     RestartOnAppFailure: false
-    AppFailureRestartDelaySeconds: 15
+    # # When app set to restart automatically on app failure, 
+    # AppFailureRestartDelaySeconds: 15
+
+# # Adjust the level of logging detail.
+# Logging:
+#     LogLevel:
+#         Default: "Trace"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/meadow.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/meadow.config.yaml
@@ -1,2 +1,43 @@
-﻿MonoControl:
-    Options: --jit
+﻿# Uncommented these options as needed.
+# To learn more about these config options, check out the OS & Device Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/
+
+# Device:
+#     # Name of the device on the network.
+#     Name: MeadowF7V2_ConfigSample
+#
+#     # Uncomment if SD card hardware present on this hardware (e.g., Core-Compute module with SD add-on)? Optional; default value is `false`.
+#     SdStorageSupported: true
+# MonoControl:
+#     # Options allow enabling debug builds or controlling JIT compilation (`--jit` to enable [default], `--interp` to disable).
+#     Options: --interp --debug
+# # Control how the ESP coprocessor will start and operate.
+# Coprocessor:
+#     # Should the ESP32 automatically attempt to connect to an access point at startup?
+#     # If set to true, wifi.config.yaml credentials must be stored in the device.
+#     AutomaticallyStartNetwork: true
+#
+#     # Should the ESP32 automatically reconnect to the configured access point?
+#     AutomaticallyReconnect: true
+#
+#     # Maximum number of retry attempts for connections etc. before an error code is returned.
+#     MaximumRetryCount: 7
+# # Network configuration.
+# Network:
+#     # Automatically attempt to get the time at startup?
+#     GetNetworkTimeAtStartup: true
+#
+#     # Time synchronization period in seconds.
+#     NtpRefreshPeriod: 600
+#
+#     # Name of the NTP servers.
+#     NtpServers:
+#         - 0.pool.ntp.org
+#         - 1.pool.ntp.org
+#         - 2.pool.ntp.org
+#         - 3.pool.ntp.org
+#
+#     # IP addresses of the DNS servers.
+#     DnsServers:
+#         - 1.1.1.1
+#         - 8.8.8.8

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/wifi.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/wifi.config.yaml
@@ -1,0 +1,8 @@
+# Uncomment to set the default Wi-Fi credentials. (This file will be processed into secure storage on the ESP32 and then deleted from the device.)
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/WiFi_Configuration/
+
+# # To enable automatically connecting to a default network, make sure to enable the Coprocessor > AutomaticallyStartNetwork value in meadow.config.yaml.
+# Credentials:
+#     Ssid: YourSSID
+#     Password: SSIDPassword

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/app.config.yaml
@@ -1,3 +1,14 @@
+# Uncomment additional options as needed.
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/Application_Settings_Configuration/
+
 Lifecycle:
+    # Control whether Meadow will restart when an unhandled app exception occurs. Combine with Lifecycle > AppFailureRestartDelaySeconds to control restart timing.
     RestartOnAppFailure: false
-    AppFailureRestartDelaySeconds: 15
+    # # When app set to restart automatically on app failure, 
+    # AppFailureRestartDelaySeconds: 15
+
+# # Adjust the level of logging detail.
+# Logging:
+#     LogLevel:
+#         Default: "Trace"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/meadow.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/meadow.config.yaml
@@ -1,2 +1,43 @@
-﻿MonoControl:
-    Options: --jit
+﻿# Uncommented these options as needed.
+# To learn more about these config options, check out the OS & Device Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/
+
+# Device:
+#     # Name of the device on the network.
+#     Name: MeadowF7V2_ConfigSample
+#
+#     # Uncomment if SD card hardware present on this hardware (e.g., Core-Compute module with SD add-on)? Optional; default value is `false`.
+#     SdStorageSupported: true
+# MonoControl:
+#     # Options allow enabling debug builds or controlling JIT compilation (`--jit` to enable [default], `--interp` to disable).
+#     Options: --interp --debug
+# # Control how the ESP coprocessor will start and operate.
+# Coprocessor:
+#     # Should the ESP32 automatically attempt to connect to an access point at startup?
+#     # If set to true, wifi.config.yaml credentials must be stored in the device.
+#     AutomaticallyStartNetwork: true
+#
+#     # Should the ESP32 automatically reconnect to the configured access point?
+#     AutomaticallyReconnect: true
+#
+#     # Maximum number of retry attempts for connections etc. before an error code is returned.
+#     MaximumRetryCount: 7
+# # Network configuration.
+# Network:
+#     # Automatically attempt to get the time at startup?
+#     GetNetworkTimeAtStartup: true
+#
+#     # Time synchronization period in seconds.
+#     NtpRefreshPeriod: 600
+#
+#     # Name of the NTP servers.
+#     NtpServers:
+#         - 0.pool.ntp.org
+#         - 1.pool.ntp.org
+#         - 2.pool.ntp.org
+#         - 3.pool.ntp.org
+#
+#     # IP addresses of the DNS servers.
+#     DnsServers:
+#         - 1.1.1.1
+#         - 8.8.8.8

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/wifi.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/wifi.config.yaml
@@ -1,0 +1,8 @@
+# Uncomment to set the default Wi-Fi credentials. (This file will be processed into secure storage on the ESP32 and then deleted from the device.)
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/WiFi_Configuration/
+
+# # To enable automatically connecting to a default network, make sure to enable the Coprocessor > AutomaticallyStartNetwork value in meadow.config.yaml.
+# Credentials:
+#     Ssid: YourSSID
+#     Password: SSIDPassword

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/app.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/app.config.yaml
@@ -1,3 +1,14 @@
+# Uncomment additional options as needed.
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/Application_Settings_Configuration/
+
 Lifecycle:
+    # Control whether Meadow will restart when an unhandled app exception occurs. Combine with Lifecycle > AppFailureRestartDelaySeconds to control restart timing.
     RestartOnAppFailure: false
-    AppFailureRestartDelaySeconds: 15
+    # # When app set to restart automatically on app failure, 
+    # AppFailureRestartDelaySeconds: 15
+
+# # Adjust the level of logging detail.
+# Logging:
+#     LogLevel:
+#         Default: "Trace"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/meadow.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/meadow.config.yaml
@@ -1,2 +1,43 @@
-﻿MonoControl:
-    Options: --jit
+﻿# Uncommented these options as needed.
+# To learn more about these config options, check out the OS & Device Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/
+
+# Device:
+#     # Name of the device on the network.
+#     Name: MeadowF7V2_ConfigSample
+#
+#     # Uncomment if SD card hardware present on this hardware (e.g., Core-Compute module with SD add-on)? Optional; default value is `false`.
+#     SdStorageSupported: true
+# MonoControl:
+#     # Options allow enabling debug builds or controlling JIT compilation (`--jit` to enable [default], `--interp` to disable).
+#     Options: --interp --debug
+# # Control how the ESP coprocessor will start and operate.
+# Coprocessor:
+#     # Should the ESP32 automatically attempt to connect to an access point at startup?
+#     # If set to true, wifi.config.yaml credentials must be stored in the device.
+#     AutomaticallyStartNetwork: true
+#
+#     # Should the ESP32 automatically reconnect to the configured access point?
+#     AutomaticallyReconnect: true
+#
+#     # Maximum number of retry attempts for connections etc. before an error code is returned.
+#     MaximumRetryCount: 7
+# # Network configuration.
+# Network:
+#     # Automatically attempt to get the time at startup?
+#     GetNetworkTimeAtStartup: true
+#
+#     # Time synchronization period in seconds.
+#     NtpRefreshPeriod: 600
+#
+#     # Name of the NTP servers.
+#     NtpServers:
+#         - 0.pool.ntp.org
+#         - 1.pool.ntp.org
+#         - 2.pool.ntp.org
+#         - 3.pool.ntp.org
+#
+#     # IP addresses of the DNS servers.
+#     DnsServers:
+#         - 1.1.1.1
+#         - 8.8.8.8

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/wifi.config.yaml
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/wifi.config.yaml
@@ -1,0 +1,8 @@
+# Uncomment to set the default Wi-Fi credentials. (This file will be processed into secure storage on the ESP32 and then deleted from the device.)
+# To learn more about these config options, including custom application configuration settings, check out the Application Settings Configuration documentation.
+# http://developer.wildernesslabs.co/Meadow/Meadow.OS/Configuration/WiFi_Configuration/
+
+# # To enable automatically connecting to a default network, make sure to enable the Coprocessor > AutomaticallyStartNetwork value in meadow.config.yaml.
+# Credentials:
+#     Ssid: YourSSID
+#     Password: SSIDPassword


### PR DESCRIPTION
[Solution approach for WildernessLabs/Meadow_Issues#184.]

Proposal for sample configs as a solution for WildernessLabs/Meadow_Issues#184, adding config files to all app templates for **app.config.yaml**, **meadow.config.yaml**, and **wifi.config.yaml**. Most items are commented out with descriptions to increase user discovery.

I installed all templates via `dotnet` and tested creating and deploying a C# and VB regular app as well as a C# Core-Compute app.
