### PR TITLE
Template unifying

### DIFF
--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/MeadowApplication.csproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplication/MeadowApplication.csproj
@@ -6,14 +6,17 @@
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meadow.Foundation" Version="0.*" />
     <PackageReference Include="Meadow.F7" Version="0.*" />
+    <PackageReference Include="Meadow.Foundation" Version="0.*" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="meadow.config.yaml">
+    <None Include="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="app.config.yaml">
+    <None Include="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="wifi.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApplication.csproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApplication.csproj
@@ -6,14 +6,17 @@
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meadow.Foundation" Version="0.*" />
     <PackageReference Include="Meadow.F7" Version="0.*" />
+    <PackageReference Include="Meadow.Foundation" Version="0.*" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="meadow.config.yaml">
+    <None Include="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="app.config.yaml">
+    <None Include="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="wifi.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/MeadowApplication.fsproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/MeadowApplication.fsproj
@@ -9,14 +9,17 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Meadow.Foundation" Version="0.*" />
     <PackageReference Include="Meadow.F7" Version="0.*" />
+    <PackageReference Include="Meadow.Foundation" Version="0.*" />
   </ItemGroup>
   <ItemGroup>
     <None Include="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="app.config.yaml">
+    <None Include="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="wifi.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApplication.vbproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeVBNet/MeadowApplication.vbproj
@@ -1,19 +1,22 @@
 <Project Sdk="Meadow.Sdk/1.1.0">
   <PropertyGroup>
-    <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <OutputType>Library</OutputType>
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meadow.Foundation" Version="0.*" />
     <PackageReference Include="Meadow.F7" Version="0.*" />
+    <PackageReference Include="Meadow.Foundation" Version="0.*" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="meadow.config.yaml">
+    <None Include="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="app.config.yaml">
+    <None Include="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="wifi.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/MeadowApplication.fsproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/MeadowApplication.fsproj
@@ -6,18 +6,20 @@
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="meadow.config.yaml" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Meadow.Foundation" Version="0.*" />
     <PackageReference Include="Meadow.F7" Version="0.*" />
+    <PackageReference Include="Meadow.Foundation" Version="0.*" />
   </ItemGroup>
   <ItemGroup>
     <None Include="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="app.config.yaml">
+    <None Include="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="wifi.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/MeadowApplication.vbproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationVBNet/MeadowApplication.vbproj
@@ -1,20 +1,22 @@
 <Project Sdk="Meadow.Sdk/1.1.0">
-
   <PropertyGroup>
-    <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <OutputType>Library</OutputType>
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meadow.Foundation" Version="0.*" />
     <PackageReference Include="Meadow.F7" Version="0.*" />
+    <PackageReference Include="Meadow.Foundation" Version="0.*" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="meadow.config.yaml">
+    <None Include="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="app.config.yaml">
+    <None Include="app.config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="wifi.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryVBNet/MeadowLibrary.vbproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryVBNet/MeadowLibrary.vbproj
@@ -1,5 +1,4 @@
 <Project Sdk="Meadow.Sdk/1.1.0">
-
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.1</TargetFramework>


### PR DESCRIPTION
[Paired with of WildernessLabs/VS_Win_Meadow_Extension#110, but neither dependent on the other.]

While adding Core-Compute templates to the VSWin extension, I tried to align all the *proj files with each other as best as I could to make future efforts to make a single source of templates easier.

This will standardize the config file includes and sort order of various files/references to make it easier to compare changes in the future.