### PR TITLE
Fix for Always Copy setting in config file includes

### DIFF
--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApplication.csproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreCompute/MeadowApplication.csproj
@@ -10,13 +10,13 @@
     <PackageReference Include="Meadow.Foundation" Version="0.*" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="meadow.config.yaml">
+    <None Update="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="app.config.yaml">
+    <None Update="app.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="wifi.config.yaml">
+    <None Update="wifi.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/MeadowApplication.fsproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationCoreComputeFSharp/MeadowApplication.fsproj
@@ -6,6 +6,9 @@
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="meadow.config.yaml" />
+    <None Include="app.config.yaml" />
+    <None Include="wifi.config.yaml" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
@@ -13,13 +16,13 @@
     <PackageReference Include="Meadow.Foundation" Version="0.*" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="meadow.config.yaml">
+    <None Update="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="app.config.yaml">
+    <None Update="app.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="wifi.config.yaml">
+    <None Update="wifi.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/MeadowApplication.fsproj
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowApplicationFSharp/MeadowApplication.fsproj
@@ -6,6 +6,9 @@
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="meadow.config.yaml" />
+    <None Include="app.config.yaml" />
+    <None Include="wifi.config.yaml" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
@@ -13,13 +16,13 @@
     <PackageReference Include="Meadow.Foundation" Version="0.*" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="meadow.config.yaml">
+    <None Update="meadow.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="app.config.yaml">
+    <None Update="app.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="wifi.config.yaml">
+    <None Update="wifi.config.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
It appears that `Update` was the better choice after all, and vitally important in F# files where we need to include files first to preserve file order (similar to the fix in WildernessLabs/VS_Win_Meadow_Extension#116).