### PR TITLE
Update short names

### DIFF
--- a/Meadow_DotNet_SDK/Project_Templates/Project_Templates.csproj
+++ b/Meadow_DotNet_SDK/Project_Templates/Project_Templates.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <Version>1.11.3</Version>
+    <Version>1.11.4</Version>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageId>WildernessLabs.Meadow.Template</PackageId>

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeCSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeCSharp/.template.config/template.json
@@ -3,10 +3,10 @@
   "author": "Wilderness Labs",
   "classifications": [ "Meadow", "Console" ],
   "name": "Meadow Core-Compute App",
-  "description": "Create a new Meadow application that runs on a Core-Compute Module",
+  "description": "A Meadow application that runs on a Core-Compute Module",
   "identity": "WildernessLabs.Meadow.CoreComputeModule.CSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.CoreComputeModule",
-  "shortName": "CoreComputeModule",
+  "shortName": "meadow-ccm-csharp",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeCSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeCSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Core-Compute Module",
   "identity": "WildernessLabs.Meadow.CoreComputeModule.CSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.CoreComputeModule",
-  "shortName": "meadow-ccm-csharp",
+  "shortName": "meadow-ccm",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeFSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeFSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Core-Compute Module",
   "identity": "WildernessLabs.Meadow.CoreComputeModule.FSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.CoreComputeModule",
-  "shortName": "meadow-ccm-fsharp",
+  "shortName": "meadow-ccm",
   "tags": {
     "language": "F#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeFSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeFSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Core-Compute Module",
   "identity": "WildernessLabs.Meadow.CoreComputeModule.FSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.CoreComputeModule",
-  "shortName": "CoreComputeModule",
+  "shortName": "meadow-ccm-fsharp",
   "tags": {
     "language": "F#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeVBNet/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeVBNet/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Core-Compute Module",
   "identity": "WildernessLabs.Meadow.CoreComputeModule.VBNET.Template",
   "groupIdentity": "WildernessLabs.Meadow.CoreComputeModule",
-  "shortName": "CoreComputeModule",
+  "shortName": "meadow-ccm-vbnet",
   "tags": {
     "language": "VB.NET",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeVBNet/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowCoreComputeVBNet/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Core-Compute Module",
   "identity": "WildernessLabs.Meadow.CoreComputeModule.VBNET.Template",
   "groupIdentity": "WildernessLabs.Meadow.CoreComputeModule",
-  "shortName": "meadow-ccm-vbnet",
+  "shortName": "meadow-ccm",
   "tags": {
     "language": "VB.NET",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowDesktopCSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowDesktopCSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow.Desktop app that runs on Windows, macOS and Linux.",
   "identity": "WildernessLabs.Meadow.Desktop.CSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.Desktop",
-  "shortName": "MeadowDesktop",
+  "shortName": "meadow-desktop",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherCSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherCSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Meadow Feather F7 board",
   "identity": "WildernessLabs.Meadow.F7Feather.CSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.F7Feather",
-  "shortName": "meadow-feather-csharp",
+  "shortName": "meadow-feather",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherCSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherCSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Meadow Feather F7 board",
   "identity": "WildernessLabs.Meadow.F7Feather.CSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.F7Feather",
-  "shortName": "F7Feather",
+  "shortName": "meadow-feather-csharp",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherFSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherFSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Meadow Feather F7 board",
   "identity": "WildernessLabs.Meadow.F7Feather.FSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.F7Feather",
-  "shortName": "meadow-feather-fsharp",
+  "shortName": "meadow-feather",
   "tags": {
     "language": "F#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherFSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherFSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Meadow Feather F7 board",
   "identity": "WildernessLabs.Meadow.F7Feather.FSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.F7Feather",
-  "shortName": "F7Feather",
+  "shortName": "meadow-feather-fsharp",
   "tags": {
     "language": "F#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherVBNet/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherVBNet/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Meadow Feather F7 board",
   "identity": "WildernessLabs.Meadow.F7Feather.VBNET.Template",
   "groupIdentity": "WildernessLabs.Meadow.F7Feather",
-  "shortName": "F7Feather",
+  "shortName": "meadow-feather-vbnet",
   "tags": {
     "language": "VB.NET",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherVBNet/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowFeatherVBNet/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Meadow Feather F7 board",
   "identity": "WildernessLabs.Meadow.F7Feather.VBNET.Template",
   "groupIdentity": "WildernessLabs.Meadow.F7Feather",
-  "shortName": "meadow-feather-vbnet",
+  "shortName": "meadow-feather",
   "tags": {
     "language": "VB.NET",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowJetsonNanoCSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowJetsonNanoCSharp/.template.config/template.json
@@ -3,10 +3,10 @@
   "author": "Wilderness Labs",
   "classifications": [ "Meadow", "Console" ],
   "name": "Meadow.Linux Jetson Nano App",
-  "description": "A Meadow Linux application that runs on a Jetson Nano",
+  "description": "A Meadow.Linux application that runs on a Jetson Nano",
   "identity": "WildernessLabs.Meadow.JetsonNano.CSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.JetsonNano",
-  "shortName": "JetsonNano",
+  "shortName": "meadow-jetson-nano",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryCSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryCSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A class library for Meadow applications",
   "identity": "WildernessLabs.Meadow.Library.CSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.Library",
-  "shortName": "meadow-library-csharp",
+  "shortName": "meadow-library",
   "tags": {
     "language": "C#",
     "type": "library"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryCSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryCSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A class library for Meadow applications",
   "identity": "WildernessLabs.Meadow.Library.CSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.Library",
-  "shortName": "Library",
+  "shortName": "meadow-library-csharp",
   "tags": {
     "language": "C#",
     "type": "library"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryFSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryFSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A class library for Meadow applications",
   "identity": "WildernessLabs.Meadow.Library.FSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.Library",
-  "shortName": "meadow-library-fsharp",
+  "shortName": "meadow-library",
   "tags": {
     "language": "F#",
     "type": "library"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryFSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryFSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A class library for Meadow applications",
   "identity": "WildernessLabs.Meadow.Library.FSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.Library",
-  "shortName": "Library",
+  "shortName": "meadow-library-fsharp",
   "tags": {
     "language": "F#",
     "type": "library"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryVBNet/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryVBNet/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A class library for Meadow applications",
   "identity": "WildernessLabs.Meadow.Library.VBNET.Template",
   "groupIdentity": "WildernessLabs.Meadow.Library",
-  "shortName": "meadow-library-vbnet",
+  "shortName": "meadow-library",
   "tags": {
     "language": "VB.NET",
     "type": "library"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryVBNet/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowLibraryVBNet/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A class library for Meadow applications",
   "identity": "WildernessLabs.Meadow.Library.VBNET.Template",
   "groupIdentity": "WildernessLabs.Meadow.Library",
-  "shortName": "Library",
+  "shortName": "meadow-library-vbnet",
   "tags": {
     "language": "VB.NET",
     "type": "library"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowProjectLabCSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowProjectLabCSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow application that runs on a Project Lab IoT accelerator",
   "identity": "WildernessLabs.Meadow.ProjectLab.CSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.ProjectLab",
-  "shortName": "ProjectLab",
+  "shortName": "meadow-project-lab",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowRaspberryPiCSharp/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowRaspberryPiCSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow Linux application that runs on a Raspberry",
   "identity": "WildernessLabs.Meadow.RaspberryPi.CSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.RaspberryPi",
-  "shortName": "RaspberryPi",
+  "shortName": "meadow-raspberry-pi",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/Meadow_DotNet_SDK/Project_Templates/templates/MeadowReTerminal/.template.config/template.json
+++ b/Meadow_DotNet_SDK/Project_Templates/templates/MeadowReTerminal/.template.config/template.json
@@ -6,7 +6,7 @@
   "description": "A Meadow Linux application that runs on Seeed Studio reTerminal",
   "identity": "WildernessLabs.Meadow.reTerminal.CSharp.Template",
   "groupIdentity": "WildernessLabs.Meadow.reTerminal",
-  "shortName": "reTerminal",
+  "shortName": "meadow-reterminal",
   "tags": {
     "language": "C#",
     "type": "project"


### PR DESCRIPTION
Update project short names, they'll look as below:

```console
WildernessLabs.Meadow.Template (version 1.11.4) is already installed, it will be replaced with latest version.
WildernessLabs.Meadow.Template::1.11.4 was successfully uninstalled.
Success: WildernessLabs.Meadow.Template::1.11.4 installed the following templates:
Template Name                  Short Name           Language        Tags
-----------------------------  -------------------  --------------  --------------
Meadow Core-Compute App        meadow-ccm           [C#],F#,VB.NET  Meadow/Console
Meadow F7 Feather App          meadow-feather       [C#],F#,VB.NET  Meadow/Console
Meadow Library                 meadow-library       [C#],F#,VB.NET  Meadow/Library
Meadow Project Lab App         meadow-project-lab   [C#]            Meadow/Console
Meadow.Desktop App             meadow-desktop       [C#]            Meadow/Console
Meadow.Linux Jetson Nano App   meadow-jetson-nano   [C#]            Meadow/Console
Meadow.Linux Raspberry Pi App  meadow-raspberry-pi  [C#]            Meadow/Console
Meadow.Linux reTerminal App    meadow-reterminal    [C#]            Meadow/Console
```